### PR TITLE
Sempre simples

### DIFF
--- a/swipemenu.js
+++ b/swipemenu.js
@@ -33,7 +33,6 @@ class SwipeMenu {
 	}
 
 	ontouchmove(event) {
-		console.log(this.menuSelector);
 		if (this.startX <= 15 || this.target.id === this.menuSelector.substr(1)) {
 			event.preventDefault();
 			event.stopPropagation();

--- a/swipemenu.js
+++ b/swipemenu.js
@@ -1,49 +1,58 @@
 /* globals document */
-/* eslint no-unused-vars: 0 */
 
 'use strict';
 
-class SwipeMenu {
-	constructor(menuID, hamburguerID, obfuscatorID) {
-		this.hamburguer = document.querySelector(hamburguerID);
-		this.obfuscator = document.querySelector(obfuscatorID);
-		this.menu = document.querySelector(menuID);
-		this.width = this.menu.getBoundingClientRect().width;
+function bubbling(target, selector) {
+	if (!target) {
+		return false;
+	}
+	if (target.matches(selector)) {
+		return target;
+	}
+	return bubbling(target.parentElement, selector);
+}
 
+class SwipeMenu {
+	constructor(menu) {
+		this.menuSelector = menu;
+		this.menu = document.querySelector(menu);
+		if (!this.menu) {
+			throw new Error('✖ Missing menu');
+		}
+		this.width = this.menu.getBoundingClientRect().width;
 		document.body.addEventListener('touchstart', this, true);
 		document.body.addEventListener('touchmove', this, true);
 		document.body.addEventListener('touchend', this, true);
-		this.hamburguer.addEventListener('click', this, false);
-		this.obfuscator.addEventListener('click', this, false);
 	}
 
 	ontouchstart(event) {
-		this.startX = parseInt(event.targetTouches[0].pageX, 10);
+		const menuIsOpen = this.menu.classList.contains('menu--open');
 		this.check = false;
+		this.startX = event.targetTouches[0].pageX;
+		this.target = menuIsOpen ? bubbling(event.target, this.menuSelector) : event.currentTarget;
 	}
 
 	ontouchmove(event) {
-		const menuOpen = this.menu.classList.contains('menu--open');
-		const target = menuOpen ? _bubblingMatchesSelector(event.target, '.menu') : event.currentTarget;
-		if (this.startX <= 15 || target.id === 'menu') {
+		console.log(this.menuSelector);
+		if (this.startX <= 15 || this.target.id === this.menuSelector.substr(1)) {
+			event.preventDefault();
+			event.stopPropagation();
+			this.check = true;
 			if (this.menu.classList.contains('menu--dragging') === false) {
 				this.menu.classList.add('menu--dragging');
 			}
-			const moveX = parseInt(event.targetTouches[0].pageX, 10);
-			const position = target.id === 'menu' ? moveX - this.startX : moveX - this.width;
+			const moveX = event.targetTouches[0].pageX;
+			const position = this.target.id === 'menu' ? moveX - this.startX : moveX - this.width;
 			if (position > -this.width && position <= 0) {
 				this.menu.style.transform = `translateX(${position}px)`;
 			}
-			this.check = true;
-			event.preventDefault();
-			event.stopPropagation();
 		}
 	}
 
 	ontouchend() {
 		if (this.check) {
 			const translateX = Number(this.menu.style.transform.replace(/[^\d]/g, ''));
-			const method = translateX < this.width / 2 ? 'hamburguerHandler' : 'obfuscatorHandler';
+			const method = translateX < this.width / 2 ? 'open' : 'close';
 			this.check = false;
 			this.menu.style.transform = '';
 			this.menu.classList.remove('menu--dragging');
@@ -51,46 +60,20 @@ class SwipeMenu {
 		}
 	}
 
-	hamburguerHandler() {
+	open() {
 		this.menu.classList.add('menu--open');
-		this.obfuscator.classList.add('is-visible');
 	}
 
-	obfuscatorHandler() {
+	close() {
 		this.menu.classList.remove('menu--open');
-		this.obfuscator.classList.remove('is-visible');
 	}
 
 	handleEvent(event) {
-		switch (event.type) {
-			case 'click':
-				if (event.target.matches('.hamburguer')) {
-					this.hamburguerHandler();
-				} else {
-					this.obfuscatorHandler();
-				}
-				break;
-			case 'touchstart':
-				this.ontouchstart(event);
-				break;
-			case 'touchmove':
-				this.ontouchmove(event);
-				break;
-			case 'touchend':
-				this.ontouchend();
-				break;
-			default:
-				break;
+		const method = `on${event.type}`;
+		if (this[method]) {
+			this[method](event);
 		}
 	}
 }
 
-function _bubblingMatchesSelector(target, selector) {
-	if (!target) {
-		return;
-	}
-	if (target.matches(selector)) {
-		return target;
-	}
-	return _bubblingMatchesSelector(target.parentElement, selector);
-}
+export default SwipeMenu;


### PR DESCRIPTION
Sei que nesse caso não afeta em nada, mas é sempre legal declarar os métodos `"privados"` no início.

Deixa simples assim!
Depois dá para extender ou utilizar a instância dentro de algum outro método.
Extendendo da pra fazer `override` dos métodos `open` e do `close`.
